### PR TITLE
Upload Modulize to pip repository

### DIFF
--- a/modulize/bin/combine_py_files.py
+++ b/modulize/bin/combine_py_files.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import os.path
 
 class burn_after_reading:

--- a/modulize/bin/modulization.py
+++ b/modulize/bin/modulization.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import sys
 from types import ModuleType
 

--- a/modulize/bin/sync_combined_py_files.py
+++ b/modulize/bin/sync_combined_py_files.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import re
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='Modulize',
+    version='1.0.0',
+    url='https://github.com/jasonrute/modulize',
+    author='Jason Rute',
+    description='A Python decorator for converting a function into a module. It also includes tools for combining multiple Python files into one.',
+    packages=find_packages(),
+    scripts=[
+        r'modulize\bin\combine_py_files.py',
+        r'modulize\bin\modulization.py',
+        r'modulize\bin\sync_combined_py_files.py'
+    ]
+)


### PR DESCRIPTION
Packaging up Modulize allows users to install it using pip and automatically register the scripts to their PATH. This means users can do `pip install modulize` and use the scripts (works with venv too).

I have added a module directory and a setup.py to enable this.

To test locally, pull this pull request and run `pip install <path-to-repo>`. You should now be able to directly use any of the scripts e.g. `combine_py_files.py`.

Once happy, please push to public pypi by following the instructions here:
https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives